### PR TITLE
Simplify entry point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ COPY --from=build-stage /home/toolop/venv /home/toolop/venv
 EXPOSE 8000
 
 # start the executable
-ENTRYPOINT ["/home/toolop/venv/bin/gunicorn", "flask_app.loader:app"]
+ENTRYPOINT ["/home/toolop/venv/bin/gunicorn", "flask_app.app:load()"]
 
 # default parameters that can be overridden with: docker run <image> new params
 CMD ["-b", ":8000", "--access-logfile", "-", "--log-level", "INFO"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
     # for local development mount and run your local copy instead of the one in the container
     volumes:
       - ./flask_app:/home/toolop/flask_app
-    entrypoint: /home/toolop/venv/bin/gunicorn flask_app.loader:app -b :8000 --workers 3 --access-logfile - --log-level INFO --reload
+    entrypoint: /home/toolop/venv/bin/gunicorn 'flask_app.app:load()' -b :8000 --workers 3 --access-logfile - --log-level INFO --reload
 
 
   # This emulates your app integrated in to the production nginx ingress config

--- a/flask_app/loader.py
+++ b/flask_app/loader.py
@@ -1,2 +1,0 @@
-from .app import load
-app = load()

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -10,7 +10,8 @@ import flask_app.app  # noqa: E402
 flask_app.app.cache = Cache(config={
     "CACHE_TYPE": "simple",
 })
-from flask_app.loader import app  # noqa: E402
+
+app = flask_app.app.load()
 
 
 def test_health_check():


### PR DESCRIPTION
Use load() as gunicorn's entry point, because we no longer are
monkeypatching in a green thread library. Free ourselves of a layer of
indirection.