### PR TITLE
Ignore docker-compose.override files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ __pycache__
 .coverage
 venv
 .tox
+docker-compose.override.yml
+docker-compose.override.yaml


### PR DESCRIPTION
A docker-compose.override.yml file may be used to, uh, override the
configuration in the docker-compose.yml file. This makes it easier to
change certain environment or service settings for local development
purposes without having to make changes to the main docker-compose file
and then avoid committing them. For example, I'm now using it to
override the DSN environment variable to use my port forwarding setup
for local database access. This commit adds docker-compose.override.yml
(or .yaml) to .gitignore, thus reserving this default override file for
developer use.