### PR TITLE
Refresh readme and dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,45 @@
 # Set up the basics
-FROM python:3.8-slim AS build-stage
+FROM python:3.8-slim AS base-stage
 
 # now do everything as toolop
 RUN adduser toolop --gecos "" --disabled-password
 RUN mkdir -p /home/toolop/app && chown -R toolop:toolop /home/toolop
 USER toolop
-
-# add the app source
 WORKDIR /home/toolop
-COPY . app
 
+# Set up an empty venv
 RUN python3 -m venv venv
-
-# activate the venv
 ENV PATH="/home/toolop/venv/bin:$PATH"
 
-# run tests with tox
-FROM build-stage AS test
+# Add the python requirements file to the container in a separate step to
+# take better advantage of layer caching. requirements.txt, and thus the
+# dependency closure, changes infrequently, so we can rebuild our containers
+# in development faster if we make sure dependencies are cached in image layers
+# that don't get invalidated when other parts of the app change.
+COPY ./requirements.txt app/
 
-# run unit tests
-WORKDIR /home/toolop/app
+# run tests with tox
+FROM base-stage AS test-stage
+
 RUN pip install tox
+
+WORKDIR /home/toolop/app
+COPY . .
+
 RUN tox
 
 # discard the test stage and actually run in production
-FROM build-stage AS deploy-stage
+FROM base-stage AS deploy-stage
 
 WORKDIR /home/toolop/app
-RUN pip install pip-tools
 
-# install production dependencies
-RUN pip-sync
+# Install production dependencies. Doing this before copying the app ensures
+# that we don't have to rebuild this layer when the requirements haven't
+# changed.
+RUN pip install -r requirements.txt
+
+WORKDIR /home/toolop/app
+COPY --from=test-stage /home/toolop/app/flask_app /home/toolop/app/flask_app
 
 # open the container port where the flask app listens
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -19,56 +19,25 @@ Getting started
 Development
 -----------
 
-The same container that runs locally for testing should run in production.
-Configuration and secrets are provided to the container at runtime.
-The application should not need to be aware of the environment it runs in.
+The development cycle looks something like this:
+
+    git clone git@github.com:uw-it-ist/example-mci-flask
+    cd example-mci-flask
+    docker-compose up -d
+    # -d makes your services run silently in the background, to tail logs:
+    docker-compose logs -f app
+    # visit localhost:8001/example-mci-flask in your browser!
+    # hack some code and reload, docker-compose.yaml mounts your local code
+    # into the running container and tells gunicorn to restart when files change
+
+    # if you make some changes to the docker file, add a library to the
+    # requirements, or you just feel like it
+    docker-compose build app
+    docker-compose restart app
 
 ### Dependency pinning
 
-    rm -rf venv
-    python3 -m venv venv && . venv/bin/activate
-    pip-sync
-
-Python dependencies are pinned using [pip-tools][]. The `requirements.in` file
-lists the direct dependencies of the application with a version constraint
-allowing minor and point release upgrades, but not major version upgrades.
-
-It's probably most sensible to install `pip-tools` in your user-wise Python
-packages, rather than inside each venv. (This recommendation may change.) All
-the below commands should be run while the venv is activated, however.
-
-To add a dependency, add a constrained requirement for it to `requirements.in`
-and run `pip-compile`.
-
-To upgrade all dependencies to new versions that match the `requirements.in`
-constraints, run `pip-compile --upgrade`. (Eventually we may have a process do
-this automatically and make pull requests.)
-
-`pip-compile`'s output is a `requirements.txt` file, which should be committed
-when it changes and never edited manually.
-
-To install the pinned dependencies in `requirements.txt` into your venv, run
-`pip-sync`.
-
-[pip-tools]: https://github.com/jazzband/pip-tools
-
-
-### Container build
-
-    # open a tunnel to the database
-    # if the app connects to more than one database cluster, you'll need
-    # to forward a different local port to each one.
-    ssh -L 5432:mario-dev01:5432 bowser-dev01
-
-    # build
-    docker-compose build
-
-    # run
-    docker-compose up
-
-    # serve
-    curl http://127.0.0.1:8001/example-flask-app/healthz
-
+See the wiki for [instructions for dependency pinning][pinning].
 
 Monitoring
 ----------
@@ -96,13 +65,9 @@ Roadmap and TODO
 ----------------
 There is still stuff to do here:
 
-- automatic deployment from github:
-    build, tag and push container to registry, flux will do the rest
-- require_weblogin_authentication might be better implemented as
-    a shared library or an external service
 - this could be further simplified to not use blueprints and look more like the
     typical tutorial apps in the flask documentation
-- another example project could provide a pattern for a javascript/angular/jquery frontend
-    with Flask as a backend API
 - HTTP/2 support
 - Asset bundling with flask_assets
+
+[pinning]: https://wiki.cac.washington.edu/display/Tools/Dependency+pinning+for+Python+applications

--- a/README.md
+++ b/README.md
@@ -23,9 +23,13 @@ The development cycle looks something like this:
 
     git clone git@github.com:uw-it-ist/example-mci-flask
     cd example-mci-flask
+    docker-compose up
+
+    # Or, to run silently in the background
     docker-compose up -d
-    # -d makes your services run silently in the background, to tail logs:
+    # and tail the logs when you need to
     docker-compose logs -f app
+
     # visit localhost:8001/example-mci-flask in your browser!
     # hack some code and reload, docker-compose.yaml mounts your local code
     # into the running container and tells gunicorn to restart when files change
@@ -34,6 +38,13 @@ The development cycle looks something like this:
     # requirements, or you just feel like it
     docker-compose build app
     docker-compose restart app
+
+    # if you're running in the foreground, Ctrl-C to shut down
+    # if you're running in the background
+    docker-compose stop
+
+    # to tear down all your containers and get a fresh start
+    docker-compose down
 
 ### Dependency pinning
 


### PR DESCRIPTION
Refresh README. Extract dependency pinning information to a wiki page, now refreshed to reflect some learning from ipfo-web port. Remove some things from the TODO that have happened.

Refresh Dockerfile based on lessons learned and applied when porting ipfo-web.

- Steps and layers are reorganized for caching efficiency and thus build speed when iterating.
- Don't bother with pip-sync inside the container build, because the requirements.txt produced by pip-compile is perfectly normal and we won't ever want to update (i.e. sync) the deps inside the container's venv, we just rebuild the container.
